### PR TITLE
Backport Ruby 3.1 fix to our custom image_optim fork

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Support Psych4/Ruby 3.1 changes to use safe_yaml methods by default [#203](https://github.com/toy/image_optim/issues/203) [#204](https://github.com/toy/image_optim/pull/204) [@oscillot](https://github.com/oscillot) [@toy](https://github.com/toy)
+
 * Introduce support for the [Guetzli JPEG encoder](https://research.googleblog.com/2017/03/announcing-guetzli-new-open-source-jpeg.html) [@ignisf](https://github.com/ignisf)
 
 ## v0.24.2 (2017-02-18)

--- a/lib/image_optim/config.rb
+++ b/lib/image_optim/config.rb
@@ -32,7 +32,8 @@ class ImageOptim
           return {}
         end
         return {} unless File.size?(full_path)
-        config = YAML.load_file(full_path)
+
+        config = load_yaml_file(full_path)
         unless config.is_a?(Hash)
           fail "expected hash, got #{config.inspect}"
         end
@@ -40,6 +41,14 @@ class ImageOptim
       rescue => e
         warn "exception when reading #{full_path}: #{e}"
         {}
+      end
+
+      def load_yaml_file(path)
+        if YAML.respond_to?(:safe_load_file)
+          YAML.safe_load_file(path, permitted_classes: [Range])
+        else
+          YAML.load_file(path)
+        end
       end
     end
 

--- a/spec/files/config_with_range.yaml
+++ b/spec/files/config_with_range.yaml
@@ -1,0 +1,3 @@
+range: !ruby/range 80..99
+number: 3
+string: foo

--- a/spec/image_optim/config_spec.rb
+++ b/spec/image_optim/config_spec.rb
@@ -205,7 +205,7 @@ describe ImageOptim::Config do
         with(path).and_return(full_path)
       expect(File).to receive(:size?).
         with(full_path).and_return(true)
-      expect(YAML).to receive(:load_file).
+      expect(IOConfig).to receive(:load_yaml_file).
         with(full_path).and_return(stringified)
 
       expect(IOConfig.read_options(path)).to eq(symbolized)
@@ -217,7 +217,7 @@ describe ImageOptim::Config do
         with(path).and_return(full_path)
       expect(File).to receive(:size?).
         with(full_path).and_return(true)
-      expect(YAML).to receive(:load_file).
+      expect(IOConfig).to receive(:load_yaml_file).
         with(full_path).and_return([:config])
 
       expect(IOConfig.read_options(path)).to eq({})
@@ -229,10 +229,46 @@ describe ImageOptim::Config do
         with(path).and_return(full_path)
       expect(File).to receive(:size?).
         with(full_path).and_return(true)
-      expect(YAML).to receive(:load_file).
+      expect(IOConfig).to receive(:load_yaml_file).
         with(full_path).and_raise
 
       expect(IOConfig.read_options(path)).to eq({})
+    end
+  end
+
+  describe '.load_yaml_file' do
+    describe 'selecting method' do
+      let(:path){ 'foo' }
+      let(:result){ 'bar' }
+      let(:yaml){ double }
+
+      before do
+        stub_const('YAML', yaml)
+      end
+
+      it 'uses YAML.safe_load_file if available' do
+        expect(yaml).to receive(:safe_load_file).
+          with(path, permitted_classes: [Range]).and_return(result)
+
+        expect(IOConfig.load_yaml_file(path)).to eq(result)
+      end
+
+      it 'uses YAML.load if safe_load_file is not available' do
+        expect(yaml).to receive(:load_file).
+          with(path).and_return(result)
+
+        expect(IOConfig.load_yaml_file(path)).to eq(result)
+      end
+    end
+
+    it 'handles yaml that includes `!ruby/range`' do
+      path = 'spec/files/config_with_range.yaml'
+
+      expect(IOConfig.load_yaml_file(path)).to eq({
+        'range' => 80..99,
+        'number' => 3,
+        'string' => 'foo',
+      })
     end
   end
 end


### PR DESCRIPTION
Backport PR from upstream to support Ruby 3.1: https://github.com/toy/image_optim/pull/204

Our custom fork (pinned at 7 years old) has two features not present in upstream. I wasn't able to get immediate consensus to drop them, and backporting the one feature I needed for Ruby 3.1 (and 3.3) was very easy, so that's this PR.

Ideally, this should be merged prior to merging the Ruby 3.3 PR on the main repo: https://github.com/code-dot-org/code-dot-org/pull/60329